### PR TITLE
Store profile

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,19 +1,24 @@
 import React, { useEffect, useRef, useState } from "react";
 import { useAccountStore } from "@/stores/useAccountStore";
+import { useStoreProfileStore } from "@/stores/useStoreProfileStore";
 import "./Header.css";
 
 const Header: React.FC = () => {
     const { user, isLoggedIn, logout } = useAccountStore();
-    const [dropdownOpen, setDropdownOpen] = useState(false);
     const dropdownRef = useRef<HTMLDivElement>(null);
+    const [dropdownOpen, setDropdownOpen] = useState(false);
+
+    const profile = useStoreProfileStore((state) => state.profile);
+    const profileDisplayName =
+        profile?.display_name || profile?.name || null;
+    const profilePicture = profile?.picture || null;
+
     const [displayName, setDisplayName] = useState<string>("");
 
-    const formatNpub = (npub: string): string => {
-        if (!npub) return "";
-        return `${npub.substring(0, 8)}...${npub.substring(npub.length - 8)}`;
-    };
+    const formatNpub = (npub: string): string =>
+        `${npub.substring(0, 8)}...${npub.substring(npub.length - 8)}`;
 
-    const handleLogout = async () => {
+    const handleLogout = () => {
         logout();
     };
 
@@ -34,103 +39,84 @@ const Header: React.FC = () => {
     }, []);
 
     useEffect(() => {
-        const fetchUserMetadata = async () => {
-            if (user && user.npub) {
-                try {
-                    const userProfile = await user.fetchProfile();
-
-                    if (userProfile && userProfile.displayName) {
-                        setDisplayName(userProfile.displayName);
-                    } else if (userProfile && userProfile.name) {
-                        setDisplayName(userProfile.name);
-                    } else {
-                        setDisplayName(formatNpub(user.npub));
-                    }
-                } catch (error) {
-                    console.error("Error fetching user metadata:", error);
-                    setDisplayName(formatNpub(user.npub));
-                }
-            }
-        };
-
-        if (isLoggedIn) {
-            fetchUserMetadata();
+        if (profileDisplayName) {
+            setDisplayName(profileDisplayName);
+        } else if (user?.npub) {
+            setDisplayName(formatNpub(user.npub));
         }
-    }, [user, isLoggedIn]);
+    }, [profileDisplayName, user?.npub]);
 
     return (
         <section className="header h-[var(--header-height)] w-screen mx-auto px-4 flex justify-between items-center border-b-2">
             {/* Logo/Title */}
             <div className="flex items-center">
                 <h1 className="text-xl font-bold text-gray-800 mr-2">
-                    {`Merchant Portal`}
+                    Merchant Portal
                 </h1>
-                <h5>{`Powered by Conduit`}</h5>
+                <h5>Powered by Conduit</h5>
             </div>
 
-            {/* Account Component */}
-            {isLoggedIn
-                ? (
-                    <div className="relative" ref={dropdownRef}>
-                        <button
-                            onClick={() => setDropdownOpen(!dropdownOpen)}
-                            className="flex items-center space-x-2 px-3 py-2 rounded-md hover:bg-gray-100 transition-colors"
-                        >
-                            {/* User Avatar - Default to a circle with first letter or icon */}
+            {/* Account Dropdown */}
+            {isLoggedIn && (
+                <div className="relative" ref={dropdownRef}>
+                    <button
+                        onClick={() => setDropdownOpen(!dropdownOpen)}
+                        className="flex items-center space-x-2 px-3 py-2 rounded-md hover:bg-gray-100 transition-colors"
+                    >
+                        {/* Avatar */}
+                        {profilePicture ? (
+                            <img
+                                src={profilePicture}
+                                alt="Profile"
+                                className="w-8 h-8 rounded-full object-cover border border-gray-300"
+                            />
+                        ) : (
                             <div className="w-8 h-8 rounded-full bg-purple-600 flex items-center justify-center text-white font-semibold">
-                                {displayName
-                                    ? displayName.charAt(0).toUpperCase()
-                                    : "N"}
-                            </div>
-
-                            <span className="hidden sm:inline text-sm font-medium">
-                                {displayName ||
-                                    formatNpub(user?.npub || "xxx")}
-                            </span>
-
-                            {/* Dropdown Arrow */}
-                            <svg
-                                className={`w-4 h-4 transition-transform ${dropdownOpen ? "rotate-180" : ""
-                                    }`}
-                                fill="none"
-                                viewBox="0 0 24 24"
-                                stroke="currentColor"
-                            >
-                                <path
-                                    strokeLinecap="round"
-                                    strokeLinejoin="round"
-                                    strokeWidth={2}
-                                    d="M19 9l-7 7-7-7"
-                                />
-                            </svg>
-                        </button>
-
-                        {/* Dropdown Menu */}
-                        {dropdownOpen && (
-                            <div className="absolute right-0 mt-2 w-48 rounded-md shadow-lg bg-white ring-1 ring-black ring-opacity-5 z-10">
-                                <div className="py-1">
-                                    <div className="px-4 py-2 border-b">
-                                        <p className="text-xs text-gray-500">
-                                            Signed in as
-                                        </p>
-                                        <p className="text-sm font-medium text-gray-800 truncate">
-                                            {formatNpub(
-                                                user!.npub || "xxx",
-                                            )}
-                                        </p>
-                                    </div>
-                                    <button
-                                        onClick={handleLogout}
-                                        className="w-full text-left block px-4 py-2 text-sm text-red-600 hover:bg-gray-100"
-                                    >
-                                        Sign out
-                                    </button>
-                                </div>
+                                {displayName ? displayName.charAt(0).toUpperCase() : "N"}
                             </div>
                         )}
-                    </div>
-                )
-                : null}
+
+                        <span className="hidden sm:inline text-sm font-medium">
+                            {displayName || formatNpub(user?.npub || "xxx")}
+                        </span>
+
+                        {/* Dropdown Arrow */}
+                        <svg
+                            className={`w-4 h-4 transition-transform ${dropdownOpen ? "rotate-180" : ""}`}
+                            fill="none"
+                            viewBox="0 0 24 24"
+                            stroke="currentColor"
+                        >
+                            <path
+                                strokeLinecap="round"
+                                strokeLinejoin="round"
+                                strokeWidth={2}
+                                d="M19 9l-7 7-7-7"
+                            />
+                        </svg>
+                    </button>
+
+                    {/* Dropdown Menu */}
+                    {dropdownOpen && (
+                        <div className="absolute right-0 mt-2 w-48 rounded-md shadow-lg bg-white ring-1 ring-black ring-opacity-5 z-10">
+                            <div className="py-1">
+                                <div className="px-4 py-2 border-b">
+                                    <p className="text-xs text-gray-500">Signed in as</p>
+                                    <p className="text-sm font-medium text-gray-800 truncate">
+                                        {formatNpub(user?.npub || "xxx")}
+                                    </p>
+                                </div>
+                                <button
+                                    onClick={handleLogout}
+                                    className="w-full text-left block px-4 py-2 text-sm text-red-600 hover:bg-gray-100"
+                                >
+                                    Sign out
+                                </button>
+                            </div>
+                        </div>
+                    )}
+                </div>
+            )}
         </section>
     );
 };

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -5,15 +5,14 @@ import "./Header.css";
 
 const Header: React.FC = () => {
     const { user, isLoggedIn, logout } = useAccountStore();
+    const { profile, fetchProfile } = useStoreProfileStore();
+
     const dropdownRef = useRef<HTMLDivElement>(null);
     const [dropdownOpen, setDropdownOpen] = useState(false);
-
-    const profile = useStoreProfileStore((state) => state.profile);
-    const profileDisplayName =
-        profile?.display_name || profile?.name || null;
-    const profilePicture = profile?.picture || null;
-
     const [displayName, setDisplayName] = useState<string>("");
+
+    const profileDisplayName = profile?.display_name || profile?.name || null;
+    const profilePicture = profile?.picture || null;
 
     const formatNpub = (npub: string): string =>
         `${npub.substring(0, 8)}...${npub.substring(npub.length - 8)}`;
@@ -21,6 +20,23 @@ const Header: React.FC = () => {
     const handleLogout = () => {
         logout();
     };
+    
+    // Innitial load
+    useEffect(() => {
+        (async () => {
+            if (isLoggedIn && user?.pubkey) {
+                await fetchProfile(user.pubkey);
+            }
+        })();
+    }, [isLoggedIn, user?.pubkey, fetchProfile]);
+
+    useEffect(() => {
+        if (profileDisplayName) {
+            setDisplayName(profileDisplayName);
+        } else if (user?.npub) {
+            setDisplayName(formatNpub(user.npub));
+        }
+    }, [profileDisplayName, user?.npub]);
 
     useEffect(() => {
         const handleClickOutside = (event: MouseEvent) => {
@@ -37,14 +53,6 @@ const Header: React.FC = () => {
             document.removeEventListener("mousedown", handleClickOutside);
         };
     }, []);
-
-    useEffect(() => {
-        if (profileDisplayName) {
-            setDisplayName(profileDisplayName);
-        } else if (user?.npub) {
-            setDisplayName(formatNpub(user.npub));
-        }
-    }, [profileDisplayName, user?.npub]);
 
     return (
         <section className="header h-[var(--header-height)] w-screen mx-auto px-4 flex justify-between items-center border-b-2">
@@ -77,7 +85,7 @@ const Header: React.FC = () => {
                         )}
 
                         <span className="hidden sm:inline text-sm font-medium">
-                            {displayName || formatNpub(user?.npub || "xxx")}
+                            {displayName || formatNpub(user?.npub || "xxx")}  {/* TODO */}
                         </span>
 
                         {/* Dropdown Arrow */}
@@ -103,7 +111,7 @@ const Header: React.FC = () => {
                                 <div className="px-4 py-2 border-b">
                                     <p className="text-xs text-gray-500">Signed in as</p>
                                     <p className="text-sm font-medium text-gray-800 truncate">
-                                        {formatNpub(user?.npub || "xxx")}
+                                        {formatNpub(user?.npub || "xxx")} {/* TODO */}
                                     </p>
                                 </div>
                                 <button

--- a/src/layouts/MainArea.tsx
+++ b/src/layouts/MainArea.tsx
@@ -5,6 +5,7 @@ import RelayPoolsLayout from "./store/RelayPoolsLayout";
 import ShippingOptionsLayout from "./store/shipping/ShippingOptionsLayout";
 import ProductEditorLayout from "./products/ProductEditorLayout";
 import StoreProfileLayout from "./store/StoreProfileLayout";
+import StoreProfileEditLayout from "./store/StoreProfileEditLayout";
 import CheckoutSettingsLayout from "./store/CheckoutSettingsLayout";
 import CompletedOrdersLayout from "./orders/CompletedOrdersLayout";
 import PendingOrdersLayout from "./orders/PendingOrdersLayout";
@@ -21,6 +22,8 @@ const MainArea = () => {
                     <Route path="/relays" component={RelayPoolsLayout} />
                     <Route path="/shipping" component={ShippingOptionsLayout} />
                     <Route path="/checkout" component={CheckoutSettingsLayout} />
+                    <Route path="/store" component={StoreProfileLayout} />
+                    <Route path="/store/edit" component={StoreProfileEditLayout} />
                 </Route>
                 <Route path="/products/create" component={ProductCreateLayout} />
                 <Route path="/products/edit/:id" component={ProductEditorLayout} />

--- a/src/layouts/store/RelayPoolsLayout.tsx
+++ b/src/layouts/store/RelayPoolsLayout.tsx
@@ -1,17 +1,117 @@
-import config from "@root/config";
+import React, { useEffect, useState } from "react";
+import { useRelayStore } from "@/stores/useRelayStore";
+import { getNdk } from "@/services/ndkService";
 
 const RelayPoolsLayout: React.FC = () => {
+    const {
+        relays,
+        addRelay,
+        removeRelay,
+        resetRelays,
+        loadRelaysFromNostr,
+        publishRelayList,
+    } = useRelayStore();
+
+    const [input, setInput] = useState("");
+
+    // Load user's relays from Kind 10002 on mount
+    useEffect(() => {
+        (async () => {
+            const ndk = await getNdk();
+            const user = await ndk.signer?.user();
+            if (user) {
+                await loadRelaysFromNostr(user.pubkey);
+            }
+        })();
+    }, [loadRelaysFromNostr]);
+
+    const handleAdd = () => {
+        try {
+            const url = new URL(input.trim());
+            addRelay(url.href);
+            setInput("");
+        } catch {
+            alert("Invalid relay URL");
+        }
+    };
+
+    const handleSyncFromNostr = async () => {
+        const ndk = await getNdk();
+        const user = await ndk.signer?.user();
+        if (user) {
+            await loadRelaysFromNostr(user.pubkey);
+            alert("✅ Synced relays from Nostr (Kind 10002)");
+        }
+    };
+
+    const handlePublish = async () => {
+        try {
+            await publishRelayList();
+            alert("✅ Relays published to Nostr (Kind 10002)");
+        } catch (err) {
+            console.error(err);
+            alert("❌ Failed to publish relays");
+        }
+    };
+
     return (
-        <section className="mx-auto p-8">
-            <h1 className="text-2xl font-bold mb-4">
-                Nostr Relay Pool
-            </h1>
-            <p className="mb-6">
-                Manage your Relays and view their status.
+        <section className="max-w-2xl mx-auto px-4 py-8">
+            <h1 className="text-2xl font-bold mb-4">Relay Pool</h1>
+            <p className="text-gray-500 mb-4">
+                Manage your preferred Nostr relays. These are used across the app for publishing and fetching events.
             </p>
-            <div className="border-2 border-white m-4 p-4">
-                {config.relays.map((relay: string) => <p key={relay}>{relay}
-                </p>)}
+
+            <ul className="space-y-2 mb-6">
+                {relays.map((url) => (
+                    <li key={url} className="flex justify-between items-center border px-3 py-2 rounded">
+                        <span>{url}</span>
+                        <button
+                            onClick={() => removeRelay(url)}
+                            className="text-sm text-red-600 hover:underline"
+                        >
+                            Remove
+                        </button>
+                    </li>
+                ))}
+            </ul>
+
+            <div className="flex gap-2 mb-4">
+                <input
+                    type="text"
+                    placeholder="wss://relay.example.com"
+                    value={input}
+                    onChange={(e) => setInput(e.target.value)}
+                    className="flex-1 px-3 py-2 border rounded"
+                />
+                <button
+                    onClick={handleAdd}
+                    className="bg-indigo-600 text-white px-4 py-2 rounded hover:bg-indigo-700"
+                >
+                    Add Relay
+                </button>
+            </div>
+
+            <div className="flex flex-wrap gap-4 mt-4 text-sm">
+                <button
+                    onClick={resetRelays}
+                    className="text-gray-600 hover:underline"
+                >
+                    Reset to default relays
+                </button>
+
+                <button
+                    onClick={handleSyncFromNostr}
+                    className="text-indigo-600 hover:underline"
+                >
+                    Sync from Nostr (Kind 10002)
+                </button>
+
+                <button
+                    onClick={handlePublish}
+                    className="text-green-600 hover:underline"
+                >
+                    Publish to Nostr (Kind 10002)
+                </button>
             </div>
         </section>
     );

--- a/src/layouts/store/StoreProfileEditLayout.tsx
+++ b/src/layouts/store/StoreProfileEditLayout.tsx
@@ -1,0 +1,190 @@
+import React, { useEffect, useState } from "react";
+import { useStoreProfileStore } from "@/stores/useStoreProfileStore";
+import { getNdk } from "@/services/ndkService";
+import { useLocation } from "wouter";
+
+const StoreProfileEditLayout: React.FC = () => {
+    const { profile, fetchProfile, updateProfile } = useStoreProfileStore();
+
+    const [form, setForm] = useState({
+        name: "",
+        display_name: "",
+        about: "",
+        website: "",
+        nip05: "",
+        lud16: "",
+        picture: "",
+        banner: "",
+    });
+
+    const [pubkey, setPubkey] = useState<string | null>(null);
+    const [editingBanner, setEditingBanner] = useState(false);
+    const [editingAvatar, setEditingAvatar] = useState(false);
+    const [, navigate] = useLocation();
+
+    useEffect(() => {
+        (async () => {
+            const ndk = await getNdk();
+            const user = await ndk.signer?.user();
+            if (user) {
+                setPubkey(user.pubkey);
+                fetchProfile(user.pubkey);
+            }
+        })();
+    }, [fetchProfile]);
+
+    useEffect(() => {
+        if (profile) {
+            setForm({
+                name: profile.name ?? "",
+                display_name: profile.display_name ?? "",
+                about: profile.about ?? "",
+                website: profile.website ?? "",
+                nip05: profile.nip05 ?? "",
+                lud16: profile.lud16 ?? "",
+                picture: profile.picture ?? "",
+                banner: profile.banner ?? "",
+            });
+        }
+    }, [profile]);
+
+    const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+        setForm({ ...form, [e.target.name]: e.target.value });
+    };
+
+    const handleSubmit = async () => {
+        if (!pubkey) return;
+        await updateProfile(pubkey, form);
+        navigate("/store");
+    };
+
+    const handleCancel = () => {
+        if (pubkey) {
+            fetchProfile(pubkey);
+            navigate("/store");
+        }
+    };
+
+    return (
+        <div className="max-w-3xl mx-auto px-4 py-8 space-y-6">
+            {/* Banner + Avatar */}
+            <div className="relative">
+                {form.banner ? (
+                    <img
+                        src={form.banner}
+                        alt="Banner"
+                        className="w-full h-48 object-cover rounded-md"
+                    />
+                ) : (
+                    <div className="w-full h-48 bg-gray-200 rounded-md" />
+                )}
+                <button
+                    onClick={() => setEditingBanner(!editingBanner)}
+                    className="absolute top-2 right-2 bg-white p-1 rounded-full shadow hover:bg-gray-100"
+                    title="Edit banner"
+                >
+                    ✏️
+                </button>
+
+                <div className="absolute -bottom-10 left-4">
+                    {form.picture ? (
+                        <img
+                            src={form.picture}
+                            alt="Avatar"
+                            className="w-20 h-20 rounded-full border-4 border-white shadow-md"
+                        />
+                    ) : (
+                        <div className="w-20 h-20 rounded-full bg-gray-300 border-4 border-white shadow-md" />
+                    )}
+                    <button
+                        onClick={() => setEditingAvatar(!editingAvatar)}
+                        className="absolute bottom-0 right-0 bg-white p-1 rounded-full shadow hover:bg-gray-100"
+                        title="Edit avatar"
+                    >
+                        ✏️
+                    </button>
+                </div>
+            </div>
+
+            <div className="mt-20">
+                {editingBanner && (
+                    <div>
+                        <p>Banner URL</p>
+                        <input
+                            type="text"
+                            name="banner"
+                            placeholder="Banner URL"
+                            value={form.banner}
+                            onChange={handleChange}
+                            className="w-full px-3 py-2 border rounded-md"
+                        />
+                    </div>
+                )}
+
+                {editingAvatar && (
+                    <div className="mt-2">
+                        <p>Avatar URL</p>
+                        <input
+                            type="text"
+                            name="picture"
+                            placeholder="Avatar URL"
+                            value={form.picture}
+                            onChange={handleChange}
+                            className="w-full px-3 py-2 border rounded-md"
+                        />
+                    </div>
+                )}
+            </div>
+
+            <div className="space-y-4 pt-12">
+                {[
+                    { label: "Store Name", name: "name" },
+                    { label: "Display Name", name: "display_name" },
+                    { label: "Website", name: "website" },
+                    { label: "NIP-05", name: "nip05" },
+                    { label: "Lightning Address", name: "lud16" },
+                ].map((field) => (
+                    <div key={field.name}>
+                        <label className="block font-medium text-sm mb-1">
+                            {field.label}
+                        </label>
+                        <input
+                            type="text"
+                            name={field.name}
+                            value={(form as any)[field.name]}
+                            onChange={handleChange}
+                            className="w-full px-4 py-2 border rounded-md"
+                        />
+                    </div>
+                ))}
+
+                <div>
+                    <label className="block font-medium text-sm mb-1">About (Bio)</label>
+                    <textarea
+                        name="about"
+                        value={form.about}
+                        onChange={handleChange}
+                        className="w-full px-4 py-2 border rounded-md"
+                    />
+                </div>
+            </div>
+
+            <div className="flex gap-4">
+                <button
+                    onClick={handleSubmit}
+                    className="bg-indigo-600 text-white px-4 py-2 rounded-md hover:bg-indigo-700"
+                >
+                    Save Changes
+                </button>
+                <button
+                    onClick={handleCancel}
+                    className="bg-gray-100 px-4 py-2 rounded-md hover:bg-gray-200"
+                >
+                    Cancel
+                </button>
+            </div>
+        </div>
+    );
+};
+
+export default StoreProfileEditLayout;

--- a/src/layouts/store/StoreProfileEditLayout.tsx
+++ b/src/layouts/store/StoreProfileEditLayout.tsx
@@ -10,7 +10,6 @@ const StoreProfileEditLayout: React.FC = () => {
         name: "",
         display_name: "",
         about: "",
-        tags: "",
         website: "",
         nip05: "",
         lud16: "",
@@ -40,7 +39,6 @@ const StoreProfileEditLayout: React.FC = () => {
                 name: profile.name ?? "",
                 display_name: profile.display_name ?? "",
                 about: profile.about ?? "",
-                tags: profile.tags ? JSON.stringify(profile.tags, null, 2) : "",
                 website: profile.website ?? "",
                 nip05: profile.nip05 ?? "",
                 lud16: profile.lud16 ?? "",
@@ -171,16 +169,6 @@ const StoreProfileEditLayout: React.FC = () => {
                     <textarea
                         name="about"
                         value={form.about}
-                        onChange={handleChange}
-                        className="w-full px-4 py-2 border rounded-md"
-                    />
-                </div>
-
-                <div>
-                    <label className="block font-medium text-sm mb-1">Tags</label>
-                    <textarea
-                        name="tags"
-                        value={form.tags}
                         onChange={handleChange}
                         className="w-full px-4 py-2 border rounded-md"
                     />

--- a/src/layouts/store/StoreProfileEditLayout.tsx
+++ b/src/layouts/store/StoreProfileEditLayout.tsx
@@ -4,12 +4,13 @@ import { getNdk } from "@/services/ndkService";
 import { useLocation } from "wouter";
 
 const StoreProfileEditLayout: React.FC = () => {
-    const { profile, fetchProfile, updateProfile } = useStoreProfileStore();
+    const { profile, fetchProfile, updateProfile, publishTestProfile, } = useStoreProfileStore();
 
     const [form, setForm] = useState({
         name: "",
         display_name: "",
         about: "",
+        tags: "",
         website: "",
         nip05: "",
         lud16: "",
@@ -39,12 +40,13 @@ const StoreProfileEditLayout: React.FC = () => {
                 name: profile.name ?? "",
                 display_name: profile.display_name ?? "",
                 about: profile.about ?? "",
+                tags: profile.tags ? JSON.stringify(profile.tags, null, 2) : "",
                 website: profile.website ?? "",
                 nip05: profile.nip05 ?? "",
                 lud16: profile.lud16 ?? "",
                 picture: profile.picture ?? "",
                 banner: profile.banner ?? "",
-            });
+            });            
         }
     }, [profile]);
 
@@ -55,6 +57,12 @@ const StoreProfileEditLayout: React.FC = () => {
     const handleSubmit = async () => {
         if (!pubkey) return;
         await updateProfile(pubkey, form);
+        navigate("/store");
+    };
+
+    const handleTest = async () => {
+        if (!pubkey) return;
+        await publishTestProfile();
         navigate("/store");
     };
 
@@ -167,6 +175,16 @@ const StoreProfileEditLayout: React.FC = () => {
                         className="w-full px-4 py-2 border rounded-md"
                     />
                 </div>
+
+                <div>
+                    <label className="block font-medium text-sm mb-1">Tags</label>
+                    <textarea
+                        name="tags"
+                        value={form.tags}
+                        onChange={handleChange}
+                        className="w-full px-4 py-2 border rounded-md"
+                    />
+                </div>
             </div>
 
             <div className="flex gap-4">
@@ -181,6 +199,12 @@ const StoreProfileEditLayout: React.FC = () => {
                     className="bg-gray-100 px-4 py-2 rounded-md hover:bg-gray-200"
                 >
                     Cancel
+                </button>
+                <button
+                    onClick={handleTest}
+                    className="bg-gray-100 px-4 py-2 rounded-md hover:bg-gray-200"
+                >
+                    Test Profile Local
                 </button>
             </div>
         </div>

--- a/src/layouts/store/StoreProfileLayout.tsx
+++ b/src/layouts/store/StoreProfileLayout.tsx
@@ -1,24 +1,13 @@
 import React, { useEffect, useState } from "react";
 import { useStoreProfileStore } from "@/stores/useStoreProfileStore";
 import { getNdk } from "@/services/ndkService";
+import { useLocation } from "wouter";
 
 const StoreProfileLayout: React.FC = () => {
-    const { profile, fetchProfile, updateProfile } = useStoreProfileStore();
+    const { profile, fetchProfile } = useStoreProfileStore();
+    const [, setPubkey] = useState<string | null>(null);
+    const [, navigate] = useLocation();
 
-    const [form, setForm] = useState({
-        name: "",
-        display_name: "",
-        about: "",
-        website: "",
-        nip05: "",
-        lud16: "",
-        picture: "",
-        banner: "",
-    });
-
-    const [pubkey, setPubkey] = useState<string | null>(null);
-
-    // Get the current user's pubkey on mount
     useEffect(() => {
         (async () => {
             const ndk = await getNdk();
@@ -30,114 +19,62 @@ const StoreProfileLayout: React.FC = () => {
         })();
     }, [fetchProfile]);
 
-    // Sync form when profile is loaded
-    useEffect(() => {
-        if (profile) {
-            setForm({
-                name: profile.name ?? "",
-                display_name: profile.display_name ?? "",
-                about: profile.about ?? "",
-                website: profile.website ?? "",
-                nip05: profile.nip05 ?? "",
-                lud16: profile.lud16 ?? "",
-                picture: profile.picture ?? "",
-                banner: profile.banner ?? "",
-            });
-        }
-    }, [profile]);
-
-    const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
-        setForm({ ...form, [e.target.name]: e.target.value });
-    };
-
-    const handleSubmit = async () => {
-        if (!pubkey) return;
-        await updateProfile(pubkey, form);
-    };
-
-    const handleCancel = () => {
-        if (pubkey) fetchProfile(pubkey);
-    };
-
     return (
-        <div className="max-w-2xl mx-auto px-4 py-8 space-y-6">
-            <h1 className="text-2xl font-bold">Store Profile</h1>
-
-            {/* BANNER PREVIEW */}
-            {form.banner && (
-                <div className="mb-4">
-                    <label className="block font-medium text-sm mb-1">Banner Preview</label>
+        <div className="max-w-3xl mx-auto px-4 py-8 space-y-6">
+            {/* Banner + Avatar */}
+            <div className="relative">
+                {profile?.banner ? (
                     <img
-                        src={form.banner}
-                        alt="Banner Preview"
-                        className="w-full h-32 object-cover rounded-md border"
+                        src={profile.banner}
+                        alt="Banner"
+                        className="w-full h-48 object-cover rounded-md"
                     />
-                </div>
-            )}
+                ) : (
+                    <div className="w-full h-48 bg-gray-200 rounded-md" />
+                )}
 
-            {/* PROFILE PICTURE PREVIEW */}
-            {form.picture && (
-                <div className="mb-4">
-                    <label className="block font-medium text-sm mb-1">Profile Picture Preview</label>
-                    <img
-                        src={form.picture}
-                        alt="Profile Preview"
-                        className="w-20 h-20 object-cover rounded-full border"
-                    />
+                <div className="absolute -bottom-10 left-4">
+                    {profile?.picture ? (
+                        <img
+                            src={profile.picture}
+                            alt="Avatar"
+                            className="w-20 h-20 rounded-full border-4 border-white shadow-md"
+                        />
+                    ) : (
+                        <div className="w-20 h-20 rounded-full bg-gray-300 border-4 border-white shadow-md" />
+                    )}
                 </div>
-            )}
+            </div>
 
-            <div className="space-y-4">
+            {/* Profile Info */}
+            <div className="pt-12 space-y-4">
                 {[
-                    { label: "Store Name", name: "name" },
-                    { label: "Display Name", name: "display_name" },
-                    { label: "Website", name: "website" },
-                    { label: "NIP-05", name: "nip05" },
-                    { label: "Lightning Address", name: "lud16" },
-                    { label: "Profile Picture URL", name: "picture" },
-                    { label: "Banner URL", name: "banner" },
+                    { label: "Store Name", value: profile?.name },
+                    { label: "Display Name", value: profile?.display_name },
+                    { label: "Website", value: profile?.website },
+                    { label: "NIP-05", value: profile?.nip05 },
+                    { label: "Lightning Address", value: profile?.lud16 },
                 ].map((field) => (
-                    <div key={field.name}>
-                        <label className="block font-medium text-sm mb-1">
+                    <div key={field.label}>
+                        <label className="block text-sm font-medium text-gray-600">
                             {field.label}
                         </label>
-                        <input
-                            type="text"
-                            name={field.name}
-                            value={(form as any)[field.name]}
-                            onChange={handleChange}
-                            className="w-full px-4 py-2 border rounded-md"
-                        />
+                        <p className="text-gray-800">{field.value || "—"}</p>
                     </div>
                 ))}
 
                 <div>
-                    <label className="block font-medium text-sm mb-1">About (Bio)</label>
-                    <textarea
-                        name="about"
-                        value={form.about}
-                        onChange={handleChange}
-                        className="w-full px-4 py-2 border rounded-md"
-                    />
+                    <label className="block text-sm font-medium text-gray-600">About</label>
+                    <p className="text-gray-800 whitespace-pre-line">{profile?.about || "—"}</p>
                 </div>
             </div>
 
-            <div className="flex gap-4">
-                <button
-                    onClick={handleSubmit}
-                    disabled={!pubkey}
-                    className="bg-indigo-600 text-white px-4 py-2 rounded-md hover:bg-indigo-700"
-                >
-                    Save Changes
-                </button>
-                <button
-                    onClick={handleCancel}
-                    disabled={!pubkey}
-                    className="bg-gray-100 px-4 py-2 rounded-md hover:bg-gray-200"
-                >
-                    Cancel
-                </button>
-            </div>
+            <button
+                onClick={() => navigate("/store/edit")}
+                className="bg-indigo-600 text-white px-4 py-2 rounded-md hover:bg-indigo-700"
+            >
+                Edit Profile
+            </button>
         </div>
     );
 };

--- a/src/layouts/store/StoreProfileLayout.tsx
+++ b/src/layouts/store/StoreProfileLayout.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect } from "react";
 import { useStoreProfileStore } from "@/stores/useStoreProfileStore";
 import { getNdk } from "@/services/ndkService";
 import { useLocation } from "wouter";

--- a/src/layouts/store/StoreProfileLayout.tsx
+++ b/src/layouts/store/StoreProfileLayout.tsx
@@ -5,7 +5,6 @@ import { useLocation } from "wouter";
 
 const StoreProfileLayout: React.FC = () => {
     const { profile, fetchProfile } = useStoreProfileStore();
-    const [, setPubkey] = useState<string | null>(null);
     const [, navigate] = useLocation();
 
     useEffect(() => {
@@ -13,7 +12,6 @@ const StoreProfileLayout: React.FC = () => {
             const ndk = await getNdk();
             const user = await ndk.signer?.user();
             if (user) {
-                setPubkey(user.pubkey);
                 fetchProfile(user.pubkey);
             }
         })();
@@ -65,8 +63,25 @@ const StoreProfileLayout: React.FC = () => {
 
                 <div>
                     <label className="block text-sm font-medium text-gray-600">About</label>
-                    <p className="text-gray-800 whitespace-pre-line">{profile?.about || "—"}</p>
+                    <p className="text-gray-800 whitespace-pre-line">
+                        {profile?.about || "—"}
+                    </p>
                 </div>
+
+                {Array.isArray(profile?.tags) && profile.tags.length > 0 && (
+                    <div>
+                        <label className="block text-sm font-medium text-gray-600">
+                            Tags
+                        </label>
+                        <ul className="text-gray-700 text-sm mt-1 space-y-1">
+                            {profile.tags.map((tag, index) => (
+                                <li key={index}>
+                                    <code>[{tag.map(t => `"${t}"`).join(", ")}]</code>
+                                </li>
+                            ))}
+                        </ul>
+                    </div>
+                )}
             </div>
 
             <button

--- a/src/layouts/store/StoreProfileLayout.tsx
+++ b/src/layouts/store/StoreProfileLayout.tsx
@@ -1,9 +1,145 @@
+import React, { useEffect, useState } from "react";
+import { useStoreProfileStore } from "@/stores/useStoreProfileStore";
+import { getNdk } from "@/services/ndkService";
+
 const StoreProfileLayout: React.FC = () => {
+    const { profile, fetchProfile, updateProfile } = useStoreProfileStore();
+
+    const [form, setForm] = useState({
+        name: "",
+        display_name: "",
+        about: "",
+        website: "",
+        nip05: "",
+        lud16: "",
+        picture: "",
+        banner: "",
+    });
+
+    const [pubkey, setPubkey] = useState<string | null>(null);
+
+    // Get the current user's pubkey on mount
+    useEffect(() => {
+        (async () => {
+            const ndk = await getNdk();
+            const user = await ndk.signer?.user();
+            if (user) {
+                setPubkey(user.pubkey);
+                fetchProfile(user.pubkey);
+            }
+        })();
+    }, [fetchProfile]);
+
+    // Sync form when profile is loaded
+    useEffect(() => {
+        if (profile) {
+            setForm({
+                name: profile.name ?? "",
+                display_name: profile.display_name ?? "",
+                about: profile.about ?? "",
+                website: profile.website ?? "",
+                nip05: profile.nip05 ?? "",
+                lud16: profile.lud16 ?? "",
+                picture: profile.picture ?? "",
+                banner: profile.banner ?? "",
+            });
+        }
+    }, [profile]);
+
+    const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+        setForm({ ...form, [e.target.name]: e.target.value });
+    };
+
+    const handleSubmit = async () => {
+        if (!pubkey) return;
+        await updateProfile(pubkey, form);
+    };
+
+    const handleCancel = () => {
+        if (pubkey) fetchProfile(pubkey);
+    };
+
     return (
-        <section>
-            <h1>Store Profile</h1>
-        </section>
-    )
-}
+        <div className="max-w-2xl mx-auto px-4 py-8 space-y-6">
+            <h1 className="text-2xl font-bold">Store Profile</h1>
+
+            {/* BANNER PREVIEW */}
+            {form.banner && (
+                <div className="mb-4">
+                    <label className="block font-medium text-sm mb-1">Banner Preview</label>
+                    <img
+                        src={form.banner}
+                        alt="Banner Preview"
+                        className="w-full h-32 object-cover rounded-md border"
+                    />
+                </div>
+            )}
+
+            {/* PROFILE PICTURE PREVIEW */}
+            {form.picture && (
+                <div className="mb-4">
+                    <label className="block font-medium text-sm mb-1">Profile Picture Preview</label>
+                    <img
+                        src={form.picture}
+                        alt="Profile Preview"
+                        className="w-20 h-20 object-cover rounded-full border"
+                    />
+                </div>
+            )}
+
+            <div className="space-y-4">
+                {[
+                    { label: "Store Name", name: "name" },
+                    { label: "Display Name", name: "display_name" },
+                    { label: "Website", name: "website" },
+                    { label: "NIP-05", name: "nip05" },
+                    { label: "Lightning Address", name: "lud16" },
+                    { label: "Profile Picture URL", name: "picture" },
+                    { label: "Banner URL", name: "banner" },
+                ].map((field) => (
+                    <div key={field.name}>
+                        <label className="block font-medium text-sm mb-1">
+                            {field.label}
+                        </label>
+                        <input
+                            type="text"
+                            name={field.name}
+                            value={(form as any)[field.name]}
+                            onChange={handleChange}
+                            className="w-full px-4 py-2 border rounded-md"
+                        />
+                    </div>
+                ))}
+
+                <div>
+                    <label className="block font-medium text-sm mb-1">About (Bio)</label>
+                    <textarea
+                        name="about"
+                        value={form.about}
+                        onChange={handleChange}
+                        className="w-full px-4 py-2 border rounded-md"
+                    />
+                </div>
+            </div>
+
+            <div className="flex gap-4">
+                <button
+                    onClick={handleSubmit}
+                    disabled={!pubkey}
+                    className="bg-indigo-600 text-white px-4 py-2 rounded-md hover:bg-indigo-700"
+                >
+                    Save Changes
+                </button>
+                <button
+                    onClick={handleCancel}
+                    disabled={!pubkey}
+                    className="bg-gray-100 px-4 py-2 rounded-md hover:bg-gray-200"
+                >
+                    Cancel
+                </button>
+            </div>
+        </div>
+    );
+};
 
 export default StoreProfileLayout;

--- a/src/services/ndkService.ts
+++ b/src/services/ndkService.ts
@@ -1,5 +1,6 @@
 import { DEFAULT_RELAYS } from "@/utils/constants";
 import NDK, { NDKNip07Signer } from "@nostr-dev-kit/ndk";
+import { useRelayStore } from "@/stores/useRelayStore";
 
 export class NDKService {
     private static instance: NDKService | null = null;
@@ -24,7 +25,7 @@ export class NDKService {
 
         return new Promise((resolve, reject) => {
             const timeout = setTimeout(() => {
-                reject(new Error('Connection timeout'));
+                reject(new Error("Connection timeout"));
             }, 10000);
 
             const checkConnection = () => {
@@ -34,16 +35,16 @@ export class NDKService {
                     resolve(this.ndk!);
                 } else if (stats.disconnected === stats.total) {
                     clearTimeout(timeout);
-                    reject(new Error('All relays disconnected'));
+                    reject(new Error("All relays disconnected"));
                 }
             };
 
-            this.ndk!.pool.on('relay:connect', (a) => {
-                console.log(`[NDK] Connected to relay: ${a.url}`);
+            this.ndk!.pool.on("relay:connect", (relay) => {
+                console.log(`[NDK] Connected to relay: ${relay.url}`);
                 checkConnection();
             });
 
-            this.ndk!.pool.on('relay:disconnect', (relay) => {
+            this.ndk!.pool.on("relay:disconnect", (relay) => {
                 console.log(`[NDK] Disconnected from relay: ${relay.url}`);
             });
 
@@ -51,13 +52,15 @@ export class NDKService {
         });
     }
 
-    // Method to reset the instance (mainly for testing purposes)
     public static reset(): void {
         NDKService.instance = null;
     }
 }
 
-export async function getNdk(relayPool: string[] = DEFAULT_RELAYS): Promise<NDK> {
+export async function getNdk(): Promise<NDK> {
+    const { relays } = useRelayStore.getState();
+    const relayPool = relays.length > 0 ? relays : DEFAULT_RELAYS;
+
     const service = NDKService.getInstance();
     return await service.initialize(relayPool);
 }

--- a/src/stores/useRelayStore.ts
+++ b/src/stores/useRelayStore.ts
@@ -1,0 +1,95 @@
+import { create } from "zustand";
+import { getNdk } from "@/services/ndkService";
+import { NDKEvent } from "@nostr-dev-kit/ndk";
+import { DEFAULT_RELAYS } from "@/utils/constants";
+
+type RelayStore = {
+  relays: string[];
+  addRelay: (url: string) => void;
+  removeRelay: (url: string) => void;
+  resetRelays: () => void;
+  loadRelaysFromNostr: (pubkey: string) => Promise<void>;
+  publishRelayList: () => Promise<void>;
+};
+
+const LOCAL_KEY = "nostr-relay-pool";
+
+export const useRelayStore = create<RelayStore>((set, get) => {
+  const saved = localStorage.getItem(LOCAL_KEY);
+  const initial = saved ? JSON.parse(saved) : DEFAULT_RELAYS;
+
+  const persist = (relays: string[]) => {
+    localStorage.setItem(LOCAL_KEY, JSON.stringify(relays));
+  };
+
+  return {
+    relays: initial,
+
+    addRelay: (url: string) => {
+      if (!url.startsWith("ws")) return;
+      set((state) => {
+        if (!state.relays.includes(url)) {
+          const updated = [...state.relays, url];
+          persist(updated);
+          return { relays: updated };
+        }
+        return state;
+      });
+    },
+
+    removeRelay: (url: string) => {
+      set((state) => {
+        const updated = state.relays.filter((r) => r !== url);
+        persist(updated);
+        return { relays: updated };
+      });
+    },
+
+    resetRelays: () => {
+      persist(DEFAULT_RELAYS);
+      set({ relays: [...DEFAULT_RELAYS] });
+    },
+
+    loadRelaysFromNostr: async (pubkey) => {
+      const ndk = await getNdk();
+      const event = await ndk.fetchEvent({
+        kinds: [10002],
+        authors: [pubkey],
+      });
+
+      if (event) {
+        const relayUrls = event.tags
+          .filter((tag) => tag[0] === "r" && typeof tag[1] === "string")
+          .map((tag) => tag[1]);
+
+        persist(relayUrls);
+        set({ relays: relayUrls });
+
+        console.log(`✅ Loaded ${relayUrls.length} relays from Kind 10002 for pubkey: ${pubkey}`, relayUrls);
+      } else {
+        console.warn(`⚠️ No Kind 10002 event found for pubkey: ${pubkey}`);
+      }
+    },
+
+    publishRelayList: async () => {
+      const ndk = await getNdk();
+      const signer = await ndk.signer?.user();
+      if (!signer) throw new Error("User not authenticated");
+
+      const relays = get().relays;
+      const tags = relays.map((url) => ["r", url]);
+
+      const event = new NDKEvent(ndk);
+      event.kind = 10002;
+      event.pubkey = signer.pubkey;
+      event.created_at = Math.floor(Date.now() / 1000);
+      event.tags = tags;
+      event.content = "";
+
+      await event.sign();
+      await event.publish();
+
+      console.log("✅ Published Kind 10002 relay list.");
+    },
+  };
+});

--- a/src/stores/useStoreProfileStore.ts
+++ b/src/stores/useStoreProfileStore.ts
@@ -68,14 +68,14 @@ export const useStoreProfileStore = create<StoreProfileStore>((set) => ({
                 ...updates,
             };
 
-            const deprecatedKeys = ["displayName"];
+            // const deprecatedKeys = ["displayName"];
 
-            for (const key of deprecatedKeys) {
-                if (key in merged) {
-                    console.warn(`Removing deprecated field: ${key}`);
-                    delete (merged as Record<string, unknown>)[key];
-                }
-            }
+            // for (const key of deprecatedKeys) {
+            //     if (key in merged) {
+            //         console.warn(`Removing deprecated field: ${key}`);
+            //         delete (merged as Record<string, unknown>)[key];
+            //     }
+            // }
 
             const newEvent = new NDKEvent(ndk, {
                 kind: 0,

--- a/src/stores/useStoreProfileStore.ts
+++ b/src/stores/useStoreProfileStore.ts
@@ -1,0 +1,78 @@
+import { create } from "zustand";
+import { getNdk } from "@/services/ndkService";
+import { NDKEvent, NDKFilter, NostrEvent } from "@nostr-dev-kit/ndk";
+
+type StoreProfile = {
+    name?: string;
+    display_name?: string;
+    about?: string;
+    website?: string;
+    picture?: string;
+    banner?: string;
+    nip05?: string;
+    lud16?: string;
+};
+
+type StoreProfileStore = {
+    profile: StoreProfile | null;
+    isLoading: boolean;
+    error: string | null;
+    fetchProfile: (pubkey: string) => Promise<void>;
+    updateProfile: (pubkey: string, data: StoreProfile) => Promise<void>;
+};
+
+export const useStoreProfileStore = create<StoreProfileStore>((set) => ({
+    profile: null,
+    isLoading: false,
+    error: null,
+
+    fetchProfile: async (pubkey: string) => {
+        set({ isLoading: true, error: null });
+
+        try {
+            const ndk = await getNdk();
+
+            const filter: NDKFilter = {
+                kinds: [0],
+                authors: [pubkey],
+                limit: 1,
+            };
+
+            const events = await ndk.fetchEvents(filter);
+            const [event] = Array.from(events);
+
+            if (event?.content) {
+                const parsed = JSON.parse(event.content);
+                set({ profile: parsed, isLoading: false });
+            } else {
+                set({ profile: null, isLoading: false });
+            }
+        } catch (err: any) {
+            console.error("Error fetching store profile:", err);
+            set({ error: err.message || "Unknown error", isLoading: false });
+        }
+    },
+
+    updateProfile: async (pubkey: string, data: StoreProfile) => {
+        try {
+            const ndk = await getNdk();
+
+            const rawEvent: NostrEvent = {
+                kind: 0,
+                pubkey,
+                created_at: Math.floor(Date.now() / 1000),
+                content: JSON.stringify(data),
+                tags: [],
+            };
+
+            const ndkEvent = new NDKEvent(ndk, rawEvent);
+            await ndkEvent.sign(); // Sign with current user keys
+            await ndkEvent.publish();
+
+            set({ profile: data });
+        } catch (err: any) {
+            console.error("Error updating store profile:", err);
+            set({ error: err.message || "Failed to save profile" });
+        }
+    },
+}));

--- a/src/stores/useStoreProfileStore.ts
+++ b/src/stores/useStoreProfileStore.ts
@@ -87,7 +87,6 @@ export const useStoreProfileStore = create<StoreProfileStore>((set) => ({
                 tags,
                 created_at: Math.floor(Date.now() / 1000),
             });
-            console.log("[debug] merged profile before publish", merged);
             await newEvent.sign();
             await newEvent.publish();
             set({ profile: merged });

--- a/src/stores/useStoreProfileStore.ts
+++ b/src/stores/useStoreProfileStore.ts
@@ -1,6 +1,7 @@
 import { create } from "zustand";
 import { getNdk } from "@/services/ndkService";
-import { NDKEvent, NDKFilter, NostrEvent } from "@nostr-dev-kit/ndk";
+import { NDKEvent } from "@nostr-dev-kit/ndk";
+import { loadUserProfileWithRelayDiscovery } from "@/utils/relayDiscovery";
 
 type StoreProfile = {
     name?: string;
@@ -11,6 +12,7 @@ type StoreProfile = {
     banner?: string;
     nip05?: string;
     lud16?: string;
+    tags?: string[][] | string;
 };
 
 type StoreProfileStore = {
@@ -19,6 +21,7 @@ type StoreProfileStore = {
     error: string | null;
     fetchProfile: (pubkey: string) => Promise<void>;
     updateProfile: (pubkey: string, data: StoreProfile) => Promise<void>;
+    publishTestProfile: () => Promise<void>;
 };
 
 export const useStoreProfileStore = create<StoreProfileStore>((set) => ({
@@ -26,53 +29,93 @@ export const useStoreProfileStore = create<StoreProfileStore>((set) => ({
     isLoading: false,
     error: null,
 
-    fetchProfile: async (pubkey: string) => {
-        set({ isLoading: true, error: null });
+    fetchProfile: async (pubkey) => {
+        try {
+          set({ isLoading: true, error: null });
+      
+          const event = await loadUserProfileWithRelayDiscovery(pubkey);
+          if (!event) {
+            set({ isLoading: false, profile: null });
+            return;
+          }
+      
+          const parsed = JSON.parse(event.content);
+          set({ profile: { ...parsed }, isLoading: false });
+        } catch (err) {
+          console.error("Failed to load profile", err);
+          set({ error: "Failed to fetch profile", isLoading: false });
+        }
+      },
 
+    updateProfile: async (pubkey, updates) => {
         try {
             const ndk = await getNdk();
 
-            const filter: NDKFilter = {
-                kinds: [0],
-                authors: [pubkey],
-                limit: 1,
-            };
+            const existing = await loadUserProfileWithRelayDiscovery(pubkey);
+            let previousData: Record<string, any> = {};
+            let tags: string[][] = existing?.tags ?? [];
 
-            const events = await ndk.fetchEvents(filter);
-            const [event] = Array.from(events);
-
-            if (event?.content) {
-                const parsed = JSON.parse(event.content);
-                set({ profile: parsed, isLoading: false });
-            } else {
-                set({ profile: null, isLoading: false });
+            if (existing) {
+                try {
+                    previousData = JSON.parse(existing.content);
+                } catch (e) {
+                    console.warn("Could not parse previous Kind 0 JSON");
+                }
             }
+
+            if (typeof updates.tags === "string") {
+                try {
+                    const parsed = JSON.parse(updates.tags);
+                    if (Array.isArray(parsed) && parsed.every((t) => Array.isArray(t))) {
+                        tags = parsed;
+                    } else {
+                        console.warn("Invalid tags format (must be string[][])");
+                    }
+                } catch {
+                    console.warn("Failed to parse tags string");
+                }
+            }
+
+            const merged = {
+                ...previousData,
+                ...updates,
+            };
+            const newEvent = new NDKEvent(ndk, {
+                kind: 0,
+                pubkey,
+                content: JSON.stringify(merged),
+                tags,
+                created_at: Math.floor(Date.now() / 1000),
+            });
+            console.log("[debug] merged profile before publish", merged);
+            await newEvent.sign();
+            await newEvent.publish();
+            set({ profile: merged });
         } catch (err: any) {
-            console.error("Error fetching store profile:", err);
-            set({ error: err.message || "Unknown error", isLoading: false });
+            console.error("Error updating store profile:", err);
+            set({ error: err.message || "Failed to update profile" });
         }
     },
 
-    updateProfile: async (pubkey: string, data: StoreProfile) => {
-        try {
-            const ndk = await getNdk();
+    publishTestProfile: async () => {
+        const ndk = await getNdk();
+        const user = await ndk.signer?.user();
+        if (!user) return;
 
-            const rawEvent: NostrEvent = {
-                kind: 0,
-                pubkey,
-                created_at: Math.floor(Date.now() / 1000),
-                content: JSON.stringify(data),
-                tags: [],
-            };
+        const event = new NDKEvent(ndk);
+        event.kind = 0;
+        event.pubkey = user.pubkey;
+        event.created_at = Math.floor(Date.now() / 1000);
+        event.tags = [["test", "true"]];
+        event.content = JSON.stringify({
+            name: "Local Test Store",
+            about: "This is a local test profile.",
+            website: "http://localhost",
+        });
 
-            const ndkEvent = new NDKEvent(ndk, rawEvent);
-            await ndkEvent.sign(); // Sign with current user keys
-            await ndkEvent.publish();
+        await event.sign();
+        await event.publish();
 
-            set({ profile: data });
-        } catch (err: any) {
-            console.error("Error updating store profile:", err);
-            set({ error: err.message || "Failed to save profile" });
-        }
+        console.log("✅ Test Kind 0 event published");
     },
 }));

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1,3 +1,15 @@
 export const DEFAULT_RELAYS = [
-    "ws://localhost:7777"
+    "ws://localhost:7777/",
+    "wss://relay.damus.io",
+    "wss://relay.nostr.band",
+    "wss://nos.lol",
+    "wss://nostr.mom",
 ];
+
+export const PUBLIC_FALLBACK_RELAYS = [
+    "wss://relay.damus.io",
+    "wss://relay.nostr.band",
+    "wss://nos.lol",
+    "wss://nostr.mom",
+];
+

--- a/src/utils/relayDiscovery.ts
+++ b/src/utils/relayDiscovery.ts
@@ -1,0 +1,38 @@
+import { getNdk } from "@/services/ndkService";
+import { PUBLIC_FALLBACK_RELAYS } from "@/utils/constants";
+import { NDKEvent } from "@nostr-dev-kit/ndk";
+
+export const loadUserProfileWithRelayDiscovery = async (
+  pubkey: string
+): Promise<NDKEvent | null> => {
+  const ndk = await getNdk();
+
+  // Step 1: Try to fetch relays from Kind 10002
+  const relayEvent = await ndk.fetchEvent({
+    kinds: [10002],
+    authors: [pubkey],
+  });
+
+  let relays = PUBLIC_FALLBACK_RELAYS;
+
+  if (relayEvent) {
+    const relayUrls = relayEvent.tags
+      .filter((tag) => tag[0] === "r" && typeof tag[1] === "string")
+      .map((tag) => tag[1]);
+
+    if (relayUrls.length > 0) {
+      relays = relayUrls;
+    }
+  }
+
+  // Step 2: Fetch Kind 0 (profile) from preferred or fallback relays
+  const events = await ndk.fetchEvents({ kinds: [0], authors: [pubkey] }, relays);
+
+  if (!events || events.size === 0) return null;
+
+  const sorted = Array.from(events).sort(
+    (a, b) => (b.created_at ?? 0) - (a.created_at ?? 0)
+  );
+
+  return sorted[0];
+};


### PR DESCRIPTION
✅ Summary of Changes: Store Profile & Draft Relay Management 
🔐 Store Profile (Kind 0)

Implemented fetchProfile() to:

- Use Kind 10002 (NIP-65) to discover user-preferred relays.

- Fallback to PUBLIC_FALLBACK_RELAYS if no relay list exists.

- Fetch Kind 0 (profile) events from discovered relays.

- Updated updateProfile() to:

- Merge new profile fields with existing Kind 0 content.

- Preserve unknown fields and tags to avoid overwriting.

- Sign and publish profile using NDK.

- Header now uses display_name (Nostr-compliant) from the store directly.

🛰️ Relay Pool Management (Kind 10002) - develompent version
Created useRelayStore to:

- Add/remove/restore relay URLs from local state.

- Persist relay list in localStorage.

- Sync relay list from user’s published Kind 10002 event.

- Publish relay list to Kind 10002

- Replaced hardcoded defaults with DEFAULT_RELAYS constant (in constants.ts).

- Refactored RelayPoolsLayout to:

- Load relays from Nostr on mount.

- Support manual sync and reset.

- Add validation to avoid invalid relay URLs.

🧼 Cleanup & Consistency

Ensured separation between public fallback relays (for profile fetching) and user-defined relay pool (for publishing).

Added logging for debug and visibility during syncing.